### PR TITLE
Constrain dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Hanno Braun <hanno@braun-robotics.com>"]
 
 
 [dependencies]
-cortex-m    = "*"
-cortex-m-rt = "*"
+cortex-m    = "0.5.4"
+cortex-m-rt = "0.5.1"
 # This is my fork of nrf52-hal. I'm depending on it for the time being, until
 # work on it has settled down a bit.
 nrf52-hal   = { git = "https://github.com/braun-robotics/nrf52-hal.git" }


### PR DESCRIPTION
When I added these dependencies, this was still a binary crate with a Cargo.lock file checked in, but this is not appropriate for a library.

@jamesmunns When I said it would be ideal if you reviewed every change, I was referring to changes to your existing crates, nrf52 and nrf52-hal. I think asking you to review every change on the new crates I'm writing is an unreasonable demand on your time, and not really necessary while initial development is going on. Therefore I won't wait for your review before merging pull requests here. You're still more than welcome to follow along and point out my mistakes, of course :grin: 