### PR TITLE
Update to latest dependency and Rust nightly versions

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -4,6 +4,7 @@ target = "thumbv7em-none-eabihf"
 [target.thumbv7em-none-eabihf]
 runner = "arm-none-eabi-gdb"
 rustflags = [
+    "-C", "linker=arm-none-eabi-gcc",
     "-C", "link-arg=-Wl,-Tlink.x",
     "-C", "link-arg=-nostartfiles",
 ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ addons:
 
 script:
   - rustup target add thumbv7em-none-eabihf
-  - cargo build --examples --features rt
+  - cargo build --verbose --examples --all-features

--- a/examples/dw1000_id.rs
+++ b/examples/dw1000_id.rs
@@ -23,6 +23,7 @@ use core::fmt::Write;
 
 use cortex_m_semihosting::hio;
 use dwm1001::{
+    dw1000,
     nrf52_hal::{
         prelude::*,
         timer::Timer,
@@ -40,7 +41,7 @@ fn main() -> ! {
 
     let mut dwm1001 = DWM1001::take().unwrap();
 
-    let dev_id = dwm1001.DW1000.dev_id()
+    let dev_id = dwm1001.DW1000.read::<dw1000::DEV_ID>()
         .expect("Failed to read DEV_ID register");
 
     let is_as_expected =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,13 @@ pub extern crate dw1000;
 pub extern crate nrf52_hal;
 
 
+/// Exports traits that are usually needed when using this crate
+pub mod prelude {
+    pub use dw1000::Register as __dwm1001__prelude__register;
+    pub use nrf52_hal::prelude::*;
+}
+
+
 use dw1000::DW1000;
 use nrf52_hal::{
     prelude::*,


### PR DESCRIPTION
This pull request changes the configuration to keep `arm-none-eabi-gcc` as the linker, despite the switch to LLD as the default linker. See https://github.com/braun-robotics/rust-dwm1001/issues/15.