### PR TITLE
WIP: Add bsp support and example for the uarte peripheral

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ embedded-hal         = "0.2.1"
 # work on it has settled down a bit.
 nrf52832-hal         = { git = "https://github.com/braun-robotics/nrf52-hal.git" }
 
+[patch."https://github.com/braun-robotics/nrf52-hal.git"]
+nrf52832-hal = { path = "../nrf52-hal/nrf52832-hal" }
+
+
 [dev-dependencies]
 heapless          = "0.3.7"
 nb                = "0.1.1"
@@ -28,6 +32,10 @@ semihosting = []                  # enable debug output in some examples
 
 [[example]]
 name              = "blink"
+required-features = ["dev", "rt"]
+
+[[example]]
+name              = "uarte"
 required-features = ["dev", "rt"]
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,8 @@ embedded-hal         = "0.2.1"
 # work on it has settled down a bit.
 nrf52832-hal         = { git = "https://github.com/braun-robotics/nrf52-hal.git" }
 
-[patch."https://github.com/braun-robotics/nrf52-hal.git"]
-nrf52832-hal = { path = "../nrf52-hal/nrf52832-hal" }
-
-
 [dev-dependencies]
-heapless          = "0.3.7"
+heapless          = "0.4.0"
 nb                = "0.1.1"
 panic-semihosting = "0.5.0"
 

--- a/examples/uarte.rs
+++ b/examples/uarte.rs
@@ -1,0 +1,50 @@
+#![no_main]
+#![no_std]
+
+
+#[macro_use] extern crate cortex_m_rt;
+#[macro_use] extern crate nb;
+
+extern crate dwm1001;
+extern crate panic_semihosting;
+
+
+use dwm1001::{
+    nrf52832_hal::{
+        prelude::*,
+        timer::Timer,
+    },
+    DWM1001,
+};
+
+
+#[entry]
+fn main() -> ! {
+    let mut dwm1001 = DWM1001::take().unwrap();
+
+    let mut timer = dwm1001.TIMER0.constrain();
+
+    let out: [u8; 6] = [
+        0x70, // P
+        0x69, // I
+        0x6e, // N
+        0x67, // G
+        0x0d, // CR
+        0x0a  // LF
+    ];
+
+    loop {
+        dwm1001.leds.D12.enable();
+        delay(&mut timer, 20_000); // 20ms
+        dwm1001.leds.D12.disable();
+        delay(&mut timer, 230_000); // 230ms
+
+        dwm1001.uart.write(&out).unwrap();
+    }
+}
+
+
+fn delay<T>(timer: &mut Timer<T>, cycles: u32) where T: TimerExt {
+    timer.start(cycles);
+    block!(timer.wait());
+}


### PR DESCRIPTION
Adds support for use of the UARTE driver from https://github.com/nrf-rs/nrf52-hal/pull/27.

This UART is wired to the debugger on the dwm1001, and is exposed via USB. You should be able to see the output of this by running `screen /dev/ttyACM0 1000000`, or similar terminal configuration.

This may be useful for eventually adding debugging, logging, or even acting as a serial modem; as I expect this interface to be /much/ faster than semihosting.

I'm calling this WIP, as I am still patching the Cargo.toml so that I can use branch from the PR linked above.

Edit: The patching I mentioned is the reason that Travis builds are failing
