### PR TITLE
Fix compilation of deprecated function use

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -716,8 +716,8 @@ impl DW_IRQ {
         gpiote.intenset.modify(|_, w| w.in0().set());
 
         interrupt::free(|_| {
-            nvic.clear_pending(Interrupt::GPIOTE);
-            nvic.clear_pending(T::INTERRUPT);
+            nrf52::NVIC::unpend(Interrupt::GPIOTE);
+            nrf52::NVIC::unpend(T::INTERRUPT);
 
             nvic.enable(Interrupt::GPIOTE);
             timer.enable_interrupt(nvic);


### PR DESCRIPTION
Compiling 093dfe69579a11945277b668dd3d75b225232a10 using `cargo build --example blink --features="dev rt"` fails with:

```
[...]
   Compiling dwm1001 v0.1.0 (/Users/nbigaouette/rust-dwm1001.git)
error: use of deprecated item 'cortex_m::peripheral::nvic::<impl cortex_m::peripheral::NVIC>::clear_pending': Use `NVIC::unpend`
   --> src/lib.rs:719:18
    |
719 |             nvic.clear_pending(Interrupt::GPIOTE);
    |                  ^^^^^^^^^^^^^
    |
note: lint level defined here
   --> src/lib.rs:9:9
    |
9   | #![deny(warnings)]
    |         ^^^^^^^^
    = note: #[deny(deprecated)] implied by #[deny(warnings)]

error: use of deprecated item 'cortex_m::peripheral::nvic::<impl cortex_m::peripheral::NVIC>::clear_pending': Use `NVIC::unpend`
   --> src/lib.rs:720:18
    |
720 |             nvic.clear_pending(T::INTERRUPT);
    |                  ^^^^^^^^^^^^^

error: aborting due to 2 previous errors

error: Could not compile `dwm1001`.
warning: build failed, waiting for other jobs to finish...
error: build failed
```

This PR will use `nrf52::NVIC::unpend()` instead to fix compilation.

I'm not sure if it's the proper way to fix this, but at least it compiles! :D