### PR TITLE
Build with all features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,3 +92,6 @@ required-features = ["dev", "rt"]
 codegen-units = 1
 lto           = true
 opt-level     = 3
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
When we do release to docs.rs, build with all features enabled to show "dev" peripherals.