### PR TITLE
Fix release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ required-features = ["dev", "rt"]
 
 
 [profile.release]
+incremental   = false
 codegen-units = 1
 lto           = true
 opt-level     = 3


### PR DESCRIPTION
Cargo has recently enabled incremental compilation by default. Since we
don't configure this explicitely, this means incremental compilation has
been enabled for our builds, too.

This caused the release build to break, as we enable link-time
optimization in the release profile, and LTO can't coexist with
incremental compilation.

This commit fixes the problem by disabling incremental compilation in
the release profile.