### PR TITLE
Fix example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,10 @@ required-features = ["dev", "rt"]
 name              = "lis2dh12"
 required-features = ["dev", "rt"]
 
+[[example]]
+name              = "uarte_heapless_string"
+required-features = ["dev", "rt"]
+
 
 [profile.release]
 incremental   = false


### PR DESCRIPTION
It would fail to build when doing so using `cargo build --examples`.