### PR TITLE
Select nRF52832 AA package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ cortex-m-rt          = "0.6.3"
 cortex-m-semihosting = "0.3.0"
 dw1000               = "0.1.0"
 embedded-hal         = "0.2.1"
-nrf52832-hal         = { git = "https://github.com/nrf-rs/nrf52-hal.git" }
+nrf52832-hal         = { git = "https://github.com/nrf-rs/nrf52-hal.git", feature = "xxAA-package" }
 
 [dev-dependencies]
 heapless          = "0.4.0"


### PR DESCRIPTION
Per the DWM1001 data sheet, section 1.2, the nRF52832 on it has 512kB
flash, 64kB RAM. Per the nRF52832 product specification, table 135,
that's the AA package, which this commit selects.

Close #67