### PR TITLE
Simplify Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ rust:
   - beta
   - nightly
 
-addons:
-  apt:
-    packages:
-      - gcc-arm-none-eabi
-
 install:
   - rustup target add thumbv7em-none-eabihf
 


### PR DESCRIPTION
The project is configured to use LLD now, so `gcc-arm-none-eabi` is no
longer required.