### PR TITLE
Update with compatibility for nrf52832 v0.8.0[-beta1].

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ dw1000               = "0.1.0"
 embedded-hal         = "0.2.1"
 
 [dependencies.nrf52832-hal]
-version          = "0.7.0"
+version          = "0.8.0-beta1"
 default-features = false
 features         = [ "xxAA-package" ]
 

--- a/examples/dw1000_only_rx.rs
+++ b/examples/dw1000_only_rx.rs
@@ -26,8 +26,8 @@ fn main() -> ! {
 
     let mut dwm1001 = DWM1001::take().unwrap();
 
-    let     clocks = dwm1001.CLOCK.constrain().freeze();
-    let mut delay  = Delay::new(dwm1001.SYST, clocks);
+    let     clocks = dwm1001.CLOCK.constrain();
+    let mut delay  = Delay::new(dwm1001.SYST);
 
     dwm1001.DW_RST.reset_dw1000(&mut delay);
     let mut dw1000 = dwm1001.DW1000.init()

--- a/examples/dw1000_only_rx.rs
+++ b/examples/dw1000_only_rx.rs
@@ -25,8 +25,6 @@ fn main() -> ! {
     debug::init();
 
     let mut dwm1001 = DWM1001::take().unwrap();
-
-    let     clocks = dwm1001.CLOCK.constrain();
     let mut delay  = Delay::new(dwm1001.SYST);
 
     dwm1001.DW_RST.reset_dw1000(&mut delay);

--- a/examples/dw1000_ranging_anchor.rs
+++ b/examples/dw1000_ranging_anchor.rs
@@ -47,8 +47,7 @@ fn main() -> ! {
 
     let mut dwm1001 = DWM1001::take().unwrap();
 
-    let     clocks = dwm1001.CLOCK.constrain().freeze();
-    let mut delay  = Delay::new(dwm1001.SYST, clocks);
+    let mut delay  = Delay::new(dwm1001.SYST);
     let mut rng    = dwm1001.RNG.constrain();
 
     dwm1001.DW_RST.reset_dw1000(&mut delay);

--- a/examples/dw1000_ranging_tag.rs
+++ b/examples/dw1000_ranging_tag.rs
@@ -46,8 +46,8 @@ fn main() -> ! {
 
     let mut dwm1001 = DWM1001::take().unwrap();
 
-    let     clocks = dwm1001.CLOCK.constrain().freeze();
-    let mut delay  = Delay::new(dwm1001.SYST, clocks);
+    let     clocks = dwm1001.CLOCK.constrain();
+    let mut delay  = Delay::new(dwm1001.SYST);
     let mut rng    = dwm1001.RNG.constrain();
 
     dwm1001.DW_RST.reset_dw1000(&mut delay);

--- a/examples/dw1000_ranging_tag.rs
+++ b/examples/dw1000_ranging_tag.rs
@@ -46,7 +46,6 @@ fn main() -> ! {
 
     let mut dwm1001 = DWM1001::take().unwrap();
 
-    let     clocks = dwm1001.CLOCK.constrain();
     let mut delay  = Delay::new(dwm1001.SYST);
     let mut rng    = dwm1001.RNG.constrain();
 

--- a/examples/dw1000_rx_tx.rs
+++ b/examples/dw1000_rx_tx.rs
@@ -42,8 +42,7 @@ fn main() -> ! {
 
     let mut dwm1001 = DWM1001::take().unwrap();
 
-    let     clocks = dwm1001.CLOCK.constrain().freeze();
-    let mut delay  = Delay::new(dwm1001.SYST, clocks);
+    let mut delay  = Delay::new(dwm1001.SYST);
     let mut rng    = dwm1001.RNG.constrain();
 
     dwm1001.DW_RST.reset_dw1000(&mut delay);


### PR DESCRIPTION
Version field not updated.

@hannobraun could you please also roll in the DW1000 update and release this when https://github.com/nrf-rs/nrf52-hal/pull/92 lands?