### PR TITLE
Release version 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,24 @@
+<a name="v0.2.0"></a>
+### v0.2.0 (2019-04-22)
+
+- Fix runtime support being enabled unconditionally ([#85], [#86])
+- Upgrade `nrf52832-hal` dependency to version 0.8 ([#87], [#91])
+- Minor documentation fixes ([#88])
+- Upgrade `dw1000` dependency to version 0.2 ([#89])
+
+[#85]: https://github.com/braun-robotics/rust-dwm1001/pull/85
+[#86]: https://github.com/braun-robotics/rust-dwm1001/pull/86
+[#87]: https://github.com/braun-robotics/rust-dwm1001/pull/87
+[#91]: https://github.com/braun-robotics/rust-dwm1001/pull/91
+[#88]: https://github.com/braun-robotics/rust-dwm1001/pull/88
+[#89]: https://github.com/braun-robotics/rust-dwm1001/pull/89
+
+
 <a name="v0.1.1"></a>
 ### v0.1.1 (2019-03-20)
 
 - Make it possible to use DWM1001 with [RTFM](https://crates.io/crates/cortex-m-rtfm) ([#82](https://github.com/braun-robotics/rust-dwm1001/pull/82))
+
 
 <a name="v0.1.0"></a>
 ### v0.1.0 (2019-02-22)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "dwm1001"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Hanno Braun <hanno@braun-robotics.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This project is still in development. No guarantee of API stability is made, so 
 Include this crate in your Cargo project by adding the following to `Cargo.toml`:
 ```toml
 [dependencies.dwm1001]
-version = "0.1"
+version = "0.2"
 ```
 
 This crate exposes various Cargo features that are useful in various situations, none of which is enabled by default:


### PR DESCRIPTION
This is basically ready, except for the final `nrf52832-hal` 0.8 release. Two things left to do, before this can be released:
- [x] Upgrade `nrf52832-hal` dependency to version 0.8, preferably in a separate PR.
- [x] Rebase this PR and finalize the changelog update (commit is currently marked as WIP).

cc @jamesmunns 